### PR TITLE
Update to 1.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,28 +1,27 @@
 buildscript {
     repositories {
         maven {
-            url "https://plugins.gradle.org/m2/"
+            url 'https://plugins.gradle.org/m2/'
         }
     }
     dependencies {
-        classpath "gradle.plugin.com.matthewprenger:CurseGradle:1.4.0"
-        classpath "org.kohsuke:github-api:1.114"
-        classpath "gradle.plugin.com.modrinth.minotaur:Minotaur:1.1.0"
+        classpath 'gradle.plugin.com.matthewprenger:CurseGradle:1.4.0'
+        classpath 'org.kohsuke:github-api:1.114'
+        classpath 'gradle.plugin.com.modrinth.minotaur:Minotaur:1.1.0'
     }
 }
 
 plugins {
-    id 'fabric-loom' version '0.6-SNAPSHOT'
+    id 'fabric-loom' version '0.10-SNAPSHOT'
     id 'maven-publish'
-    id 'org.cadixdev.licenser' version '0.5.0'
-    id "signing"
-    id "maven"
-    id "com.modrinth.minotaur" version "1.1.0"
-    id "com.matthewprenger.cursegradle" version "1.4.0"
+    id 'org.cadixdev.licenser' version '0.6.1'
+    id 'signing'
+    id 'com.modrinth.minotaur' version '1.1.0'
+    id 'com.matthewprenger.cursegradle' version '1.4.0'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -31,25 +30,14 @@ group = project.maven_group
 repositories {
     mavenCentral()
     maven {
-        url "https://jitpack.io"
+        url 'https://jitpack.io'
     }
 }
 
-ext.changelog = ""
-
-tasks.withType(Sign) {
-    onlyIf { project.hasProperty("sign") }
-}
-
-if (project.hasProperty("sign")) {
-    signing {
-        useGpgCmd()
-        sign configurations.archives
-    }
-}
+ext.changelog = ''
 
 license {
-    header = rootProject.file("LICENSE")
+    header(rootProject.file('LICENSE'))
 }
 
 dependencies {
@@ -58,18 +46,18 @@ dependencies {
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-    ["fabric-command-api-v1"].forEach {
+    ['fabric-command-api-v1'].forEach {
         include(modImplementation(fabricApi.module(it, project.fabric_version)))
     }
 
-    modImplementation(include("com.oroarmor:oro-config-fabric:2.0.0"))
+    modImplementation(include('com.oroarmor:oro-config-fabric:2.0.0'))
 }
 
 processResources {
-    inputs.property "version", project.version
+    inputs.property 'version', project.version
 
-    filesMatching("fabric.mod.json") {
-        expand "version": project.version
+    filesMatching('fabric.mod.json') {
+        expand 'version': project.version
     }
 }
 
@@ -78,15 +66,7 @@ tasks.withType(JavaCompile).configureEach {
     // this fixes some edge cases with special characters not displaying correctly
     // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
     // If Javadoc is generated, this must be specified in that task too.
-    it.options.encoding = "UTF-8"
-
-    // The Minecraft launcher currently installs Java 8 for users, so your mod probably wants to target Java 8 too
-    // JDK 9 introduced a new way of specifying this that will make sure no newer classes or methods are used.
-    // We'll use that if it's available, but otherwise we'll use the older option.
-    def targetVersion = 8
-    if (JavaVersion.current().isJava9Compatible()) {
-        it.options.release = targetVersion
-    }
+    it.options.encoding = 'UTF-8'
 }
 
 java {
@@ -102,7 +82,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 jar {
-    from("LICENSE") {
+    from('LICENSE') {
         rename { "${it}_${project.archivesBaseName}" }
     }
 }
@@ -111,76 +91,104 @@ artifacts {
     archives jar, sourcesJar, javadocJar
 }
 
-uploadArchives {
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.artifacts.repositories.PasswordCredentials
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            name = 'Custom Item Range Combination'
+            description = 'Allows for the changing of how far item entities combine in Minecraft.'
+            url = 'http://github.com/OroArmor/CustomItemRangeCombination'
+
+            licenses {
+                license {
+                    name = 'MIT'
+                    url = 'https://mit-license.org/'
+                }
+            }
+
+            developers {
+                developer {
+                    id = 'OroArmor'
+                    name = 'Eli Orona'
+                    email = 'eliorona@live.com'
+                    url = 'oroarmor.com'
+                }
+            }
+
+            scm {
+                connection = 'scm:git:git://github.com/OroArmor/CustomItemRangeCombination.git'
+                developerConnection = 'scm:git:ssh://github.com:OroArmor/CustomItemRangeCombination.git'
+                url = 'http://github.com/OroArmor/CustomItemRangeCombination'
+            }
+        }
+    }
+
     repositories {
-        mavenDeployer {
-            def ossrhUsername = "OroArmor"
-            def ossrhPassword = project.hasProperty("ossrhPassword") ? project.property("ossrhPassword") : System.getenv("OSSRH_PASSWORD")
+        maven {
+            name = 'Sonatype Staging'
+            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+            credentials(PasswordCredentials) {
+                def ossrhUsername = 'OroArmor'
+                def ossrhPassword = project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') : System.getenv('OSSRH_PASSWORD')
 
-            beforeDeployment {
-                MavenDeployment deployment -> signing.signPom(deployment)
+                username = ossrhUsername
+                password = ossrhPassword
             }
+        }
 
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
+        maven {
+            name = 'Sonatype Snapshot'
+            url = 'https://oss.sonatype.org/content/repositories/snapshots/'
+            credentials(PasswordCredentials) {
+                def ossrhUsername = 'OroArmor'
+                def ossrhPassword = project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') : System.getenv('OSSRH_PASSWORD')
 
-            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
-            pom.project {
-                name 'Custom Item Range Combination'
-                packaging 'jar'
-                // optionally artifactId can be defined here
-                description 'Allows for the changing of how far item entities combine in Minecraft.'
-                url 'http://github.com/OroArmor/CustomItemRangeCombination'
-
-                scm {
-                    connection 'scm:git:git://github.com/OroArmor/CustomItemRangeCombination.git'
-                    developerConnection 'scm:git:ssh://github.com:OroArmor/CustomItemRangeCombination.git'
-                    url 'http://github.com/OroArmor/CustomItemRangeCombination'
-                }
-
-                licenses {
-                    license {
-                        name 'MIT'
-                        url 'https://mit-license.org/'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id 'OroArmor'
-                        name 'Eli Orona'
-                        email 'eliorona@live.com'
-                        url "oroarmor.com"
-                    }
-                }
+                username = ossrhUsername
+                password = ossrhPassword
             }
         }
     }
 }
 
+signing {
+    sign publishing.publications.mavenJava
+}
+
+tasks.withType(Sign) {
+    onlyIf {
+        project.hasProperty('sign')
+    }
+}
+
+if (project.hasProperty('sign')) {
+    signing {
+        useGpgCmd()
+        sign configurations.archives
+    }
+}
+
 curseforge {
-    if (System.getenv("CURSE_API_KEY") != null) {
-        apiKey = System.getenv("CURSE_API_KEY")
+    if (System.getenv('CURSE_API_KEY') != null) {
+        apiKey = System.getenv('CURSE_API_KEY')
         project {
             id = project.curseforge_id
-            releaseType = "release"
-            project.game_versions.split(",").each { String game_version -> addGameVersion game_version }
-            addGameVersion "Fabric"
+            releaseType = 'release'
+            project.game_versions.split(',').each { String game_version -> addGameVersion game_version }
+            addGameVersion 'Fabric'
 
-            changelogType = "html"
+            changelogType = 'html'
             changelog = project.ext.changelog
 
 //			relations {
-//				requiredDependency "fabric-api"
+//				requiredDependency 'fabric-api'
 //			}
             mainArtifact(remapJar.archivePath) {
-                displayName = "Custom Item Range Combination - $rootProject.mod_version"
+                displayName = 'Custom Item Range Combination - $rootProject.mod_version'
             }
             afterEvaluate {
-                uploadTask.dependsOn("build")
+                uploadTask.dependsOn('build')
             }
         }
     }
@@ -193,12 +201,12 @@ curseforge {
 import com.modrinth.minotaur.TaskModrinthUpload
 
 task publishToModrinth(type: TaskModrinthUpload) {
-    token = System.getenv("MODRINTH_TOKEN") // Use an environment property!
+    token = System.getenv('MODRINTH_TOKEN') // Use an environment property!
     projectId = project.modrinth_id
     versionNumber = project.version
     uploadFile = remapJar.archivePath // This is the java jar task
     changelog = project.ext.changelog
-    project.game_versions.split(",").each { String game_version -> addGameVersion(game_version) }
+    project.game_versions.split(',').each { String game_version -> addGameVersion(game_version) }
     addLoader('fabric')
 }
 
@@ -209,28 +217,28 @@ task github {
 
     doLast {
         def github = org.kohsuke.github.GitHub.connectUsingOAuth(System.getenv().GITHUB_TOKEN as String)
-        def repository = github.getRepository("OroArmor/CustomItemRangeCombination")
+        def repository = github.getRepository('OroArmor/CustomItemRangeCombination')
 
         def releaseBuilder = new org.kohsuke.github.GHReleaseBuilder(repository, project.mod_version)
         releaseBuilder.name("$project.project_name $project.mod_version for $project.minecraft_version")
         releaseBuilder.body(project.ext.changelog)
-        releaseBuilder.commitish("master")
+        releaseBuilder.commitish('master')
 
         def ghRelease = releaseBuilder.create()
-        ghRelease.uploadAsset(file("${project.rootDir}/build/libs/${archivesBaseName}-${version}.jar"), "application/java-archive");
+        ghRelease.uploadAsset(file("${project.rootDir}/build/libs/${archivesBaseName}-${version}.jar"), 'application/java-archive');
     }
 }
 
 task generateChangelog {
-    def changelogFile = file("CHANGELOG.md")
-    def contents = ""
+    def changelogFile = file('CHANGELOG.md')
+    def contents = ''
     changelogFile.withReader { reader ->
         def line
         while ((line = reader.readLine()) != null)
-            contents += line + "\n"
+            contents += line + '\n'
     }
 
-    def changelogs = contents.split("\\-\\-\\-\\-")
+    def changelogs = contents.split('\\-\\-\\-\\-')
     project.ext.changelog = changelogs.find { log -> log.contains(project.version) }
     println project.ext.changelog
 }

--- a/build.gradle
+++ b/build.gradle
@@ -97,37 +97,39 @@ import org.gradle.api.artifacts.repositories.PasswordCredentials
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            name = 'Custom Item Range Combination'
-            description = 'Allows for the changing of how far item entities combine in Minecraft.'
-            url = 'http://github.com/OroArmor/CustomItemRangeCombination'
-
-            licenses {
-                license {
-                    name = 'MIT'
-                    url = 'https://mit-license.org/'
-                }
-            }
-
-            developers {
-                developer {
-                    id = 'OroArmor'
-                    name = 'Eli Orona'
-                    email = 'eliorona@live.com'
-                    url = 'oroarmor.com'
-                }
-            }
-
-            scm {
-                connection = 'scm:git:git://github.com/OroArmor/CustomItemRangeCombination.git'
-                developerConnection = 'scm:git:ssh://github.com:OroArmor/CustomItemRangeCombination.git'
+            pom {
+                name = 'Custom Item Range Combination'
+                description = 'Allows for the changing of how far item entities combine in Minecraft.'
                 url = 'http://github.com/OroArmor/CustomItemRangeCombination'
+
+                licenses {
+                    license {
+                        name = 'MIT'
+                        url = 'https://mit-license.org/'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'OroArmor'
+                        name = 'Eli Orona'
+                        email = 'eliorona@live.com'
+                        url = 'oroarmor.com'
+                    }
+                }
+
+                scm {
+                    connection = 'scm:git:git://github.com/OroArmor/CustomItemRangeCombination.git'
+                    developerConnection = 'scm:git:ssh://github.com:OroArmor/CustomItemRangeCombination.git'
+                    url = 'http://github.com/OroArmor/CustomItemRangeCombination'
+                }
             }
         }
     }
 
     repositories {
         maven {
-            name = 'Sonatype Staging'
+            name = 'SonatypeStaging'
             url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
             credentials(PasswordCredentials) {
                 def ossrhUsername = 'OroArmor'
@@ -139,7 +141,7 @@ publishing {
         }
 
         maven {
-            name = 'Sonatype Snapshot'
+            name = 'SonatypeSnapshot'
             url = 'https://oss.sonatype.org/content/repositories/snapshots/'
             credentials(PasswordCredentials) {
                 def ossrhUsername = 'OroArmor'

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,17 +2,17 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.16.5
-yarn_mappings=1.16.5+build.6
-loader_version=0.11.3
+minecraft_version=1.18
+yarn_mappings=1.18+build.1
+loader_version=0.12.8
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.0.2
 maven_group=com.oroarmor
 archives_base_name=custom-item-range-combination
 project_name=Custom Item Range Combination
 # publishing
 modrinth_id=bkORLvAT
 curseforge_id=462345
-game_versions=1.16.4,1.16.5
+game_versions=1.18,1.18.1
 # Dependencies
 fabric_version=0.32.5+1.16

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Very simple update to 1.18. Only buildscript, gradle version, and gradle properties were changed.

Also, removed the `maven` plugin because it no longer exists, so it's using the `maven-publications` plugin.
Have not tested the publishing, but it was copied from a builscript I use which I know works.